### PR TITLE
Add STeeR strategy webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@
 Maldoju/Maldoju is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## Webapp
+Open `index.html` in a browser to explore the interactive STeeR strategy summary.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>STeeR Strategy & Business Design</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+<h1>STeeR Strategy & Business Design</h1>
+<nav>
+<ul>
+<li><a href="#intro">Introduction</a></li>
+<li><a href="#aspiration">Aspiration Gagnante</a></li>
+<li><a href="#play">O&ugrave; jouer</a></li>
+<li><a href="#win">Comment gagner</a></li>
+<li><a href="#capabilities">Capacit&eacute;s</a></li>
+<li><a href="#management">Syst&egrave;mes de gestion</a></li>
+</ul>
+</nav>
+</header>
+<main>
+<section id="intro" class="collapsible">
+<h2>Introduction : Contexte Strat&eacute;gique chez Deloitte (STeeR)</h2>
+<div class="content">
+<p>L'activit&eacute; de conseil de Deloitte en France se structure autour de deux m&eacute;tiers&nbsp;: <strong>Strategy, Risk &amp; Transactions</strong> (SR&amp;T) qui r&eacute;pond au <em>Pourquoi et quoi faire ?</em>, et <strong>Technology &amp; Transformation</strong> (T&amp;T) qui r&eacute;pond au <em>Comment et avec quoi le r&eacute;aliser ?</em> Face &agrave; l'impr&eacute;visibilit&eacute; croissante du monde, SR&amp;T a &eacute;volu&eacute; vers l'approche <strong>STeeR</strong>, enrichie de deux dimensions&nbsp;: <em>Ecosystemic</em> et <em>Emergence</em>. STeeR vise &agrave; fournir des r&eacute;ponses robustes aux grands d&eacute;fis de la d&eacute;cennie&nbsp;: une strat&eacute;gie pr&eacute;par&eacute;e aux chocs, un M&amp;A pens&eacute; pour la transition, et une gestion des risques qui construit l'organisation <q>anti-fragile</q>.</p>
+<p>La pratique <em>FSI Strategy &amp; Business Design</em>, fond&eacute;e par Julien Maldonato et Ghislain Boulnois, s'inscrit au sein du pilier Strat&eacute;gie de STeeR.</p>
+</div>
+</section>
+<section id="aspiration" class="collapsible">
+<h2>1. Aspiration gagnante</h2>
+<div class="content">
+<p><strong>Aspiration quantitative&nbsp;:</strong> Atteindre 25 M&euro; de chiffre d'affaires en 5 ans tout en maintenant une marge op&eacute;rationnelle sup&eacute;rieure &agrave; 40%. Cette croissance forte implique des services &agrave; tr&egrave;s forte valeur ajout&eacute;e.</p>
+<p><strong>Aspiration qualitative&nbsp;:</strong> Devenir le partenaire strat&eacute;gique de r&eacute;f&eacute;rence pour aider les acteurs financiers &agrave; concevoir des trajectoires de valeur audacieuses et pr&eacute;par&eacute;es aux incertitudes.</p>
+</div>
+</section>
+<section id="play" class="collapsible">
+<h2>2. O&ugrave; allons-nous jouer&nbsp;?</h2>
+<div class="content">
+<p>Notre champ d'action couvre tout l'&eacute;cosyst&egrave;me des services financiers&nbsp;:</p>
+<ul>
+<li><strong>Fournisseurs traditionnels</strong> (banques, assurances, asset managers) &agrave; r&eacute;inventer.</li>
+<li><strong>Nouveaux entrants et FinTech</strong> &agrave; faire scaler.</li>
+<li><strong>Consommateurs de services financiers</strong> int&eacute;grant la finance &agrave; leurs offres (Embedded Finance).</li>
+</ul>
+<p>Focalisation sur la France avec des opportunit&eacute;s EMEA.</p>
+</div>
+</section>
+<section id="win" class="collapsible">
+<h2>3. Comment allons-nous gagner&nbsp;?</h2>
+<div class="content">
+<p>En appliquant syst&eacute;matiquement le cadre des <em>Dix Types d'Innovation</em> pour cr&eacute;er de nouveaux mod&egrave;les d'affaires adoss&eacute;s &agrave; l'IA agentique, aux wallets num&eacute;riques et &agrave; la tokenisation.</p>
+<h3>Configuration</h3>
+<ul>
+<li><strong>Mod&egrave;le de profit&nbsp;:</strong> revenus hybrides li&eacute;s &agrave; l'impact ESG.</li>
+<li><strong>R&eacute;seau&nbsp;:</strong> plateformes collaboratives via smart contracts.</li>
+<li><strong>Structure&nbsp;:</strong> organisations agiles et allocation dynamique des ressources.</li>
+<li><strong>Processus&nbsp;:</strong> r&eacute;invention de la cha&icirc;ne de valeur gr&acirc;ce &agrave; l'IA et aux Wallets.</li>
+</ul>
+<h3>Offre</h3>
+<ul>
+<li><strong>Performance produit&nbsp;:</strong> produits financiers Net&nbsp;Zero &agrave; tra&ccedil;abilit&eacute; carbone.</li>
+<li><strong>Syst&egrave;me de produits&nbsp;:</strong> services financiers modulaires via API.</li>
+</ul>
+<h3>Exp&eacute;rience</h3>
+<ul>
+<li><strong>Service&nbsp;:</strong> assistants conversationnels g&eacute;rant les requ&ecirc;tes standard.</li>
+<li><strong>Canal&nbsp;:</strong> le wallet devient point d'entr&eacute;e unique.</li>
+<li><strong>Marque&nbsp;:</strong> confiance bas&eacute;e sur une r&eacute;putation d&eacute;centralis&eacute;e.</li>
+<li><strong>Engagement client&nbsp;:</strong> r&eacute;compenses tokenis&eacute;es incitant aux comportements vertueux.</li>
+</ul>
+</div>
+</section>
+<section id="capabilities" class="collapsible">
+<h2>4. Quelles capacit&eacute;s mettre en place&nbsp;?</h2>
+<div class="content">
+<p>La pratique doit s'appuyer sur&nbsp;:</p>
+<ul>
+<li>Un <strong>capital humain</strong> d'experts hybrides en strat&eacute;gie et technologie.</li>
+<li>Une <strong>expertise multi-domaines</strong> (r&eacute;glementation FSI, innovation, IA, wallets, tokenisation).</li>
+<li>Des <strong>m&eacute;thodologies de business design</strong> int&eacute;grant l'approche Ecosystemic et Emergence.</li>
+<li>Un <strong>r&eacute;seau de partenariats technologiques</strong> pour concr&eacute;tiser rapidement les visions clients.</li>
+</ul>
+</div>
+</section>
+<section id="management" class="collapsible">
+<h2>5. Quels syst&egrave;mes de gestion&nbsp;?</h2>
+<div class="content">
+<ul>
+<li><strong>Pilotage de la performance&nbsp;:</strong> tableau de bord temps r&eacute;el incluant KPIs financiers et non-financiers.</li>
+<li><strong>D&eacute;veloppement des talents&nbsp;:</strong> recrutement et formation continue, avec des <em>tours of duty</em> en startups partenaires.</li>
+<li><strong>Gouvernance agile&nbsp;:</strong> prise de d&eacute;cision rapide et culture du <em>pivot</em>.</li>
+</ul>
+</div>
+</section>
+</main>
+<footer>
+<p>&copy; 2024 Deloitte France - FSI Strategy &amp; Business Design</p>
+</footer>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const sections = document.querySelectorAll('.collapsible');
+  sections.forEach(sec => {
+    const header = sec.querySelector('h2');
+    header.addEventListener('click', () => {
+      sec.classList.toggle('active');
+    });
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,65 @@
+body {
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    background: #000;
+    color: #00ff99;
+}
+
+header {
+    background: #001a33;
+    padding: 1rem;
+    text-align: center;
+}
+
+h1 {
+    margin: 0;
+    color: #00ffff;
+}
+
+nav ul {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+}
+
+nav a {
+    color: #00ff99;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+nav a:hover {
+    color: #00ffff;
+}
+
+main {
+    max-width: 1000px;
+    margin: auto;
+    padding: 1rem;
+}
+
+section {
+    margin-bottom: 2rem;
+}
+
+.collapsible > h2 {
+    cursor: pointer;
+}
+
+.content {
+    display: none;
+    padding-top: 0.5rem;
+}
+
+footer {
+    background: #001a33;
+    text-align: center;
+    padding: 1rem;
+    color: #00ffff;
+}
+
+.active .content {
+    display: block;
+}


### PR DESCRIPTION
## Summary
- add rich interactive webapp summarizing STeeR Strategy & Business Design
- style with dark theme and neon colors
- include simple collapsible sections via JavaScript
- document webapp usage in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845e3609f108322a2827977b483ab03